### PR TITLE
added examples to display turbidity sensor reading on lcd

### DIFF
--- a/examples/turbidity_lcd.py
+++ b/examples/turbidity_lcd.py
@@ -1,0 +1,17 @@
+#program reads analog turbidity sensor value
+#displays it on the lcd screen
+
+from cloudmesh.pi import LCD
+from cloudmesh.pi import TurbiditySensorAnalog
+import time
+#connect turbidity sensor to port A0 of grovepi
+# connect LCD to I2C port of grovepi
+
+turb = TurbiditySensorAnalog(pin=0)
+screen = LCD()
+screen.setRGB(0,128,0)
+
+while True:
+	value = turb.getValue()
+	screen.setText("Turbidity : " + str(value) )
+	time.sleep(1)

--- a/examples/turbidity_ledbar_lcd.py
+++ b/examples/turbidity_ledbar_lcd.py
@@ -1,0 +1,26 @@
+# read analog value on turbidity sensor
+# display the reading on lcd screen
+# display a level on the ledbar
+
+# high reading means less turbidity ahd hence is good
+
+from cloudmesh.pi import LedBar
+from cloudmesh.pi import LCD
+from cloudmesh.pi import TurbiditySensorAnalog
+import time
+#connect lcd to i2c port
+#connect turbidity sensor to analog port A0
+#connect ledbar to digital port D3
+
+lcd = LCD()
+lcd.setRGB(0,128,0)
+ledbar = LedBar(pin=3)
+turb = TurbiditySensorAnalog(pin=0)
+
+while True:
+	value = turb.getValue()
+	level = value/100
+	ledbar.setLevel(level)
+	lcd.setText("Turbidity : " + str(value) )
+	time.sleep(1)
+


### PR DESCRIPTION
1. Read turbidity sensor analog value and display on the lcd
2. Display corresponding level on the ledbar